### PR TITLE
Add healthcheck system to docker-compose configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM stoplight/prism
 
 RUN apk update
+RUN apk add curl
 COPY docs docs

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mock Microservice Endpoints
 
-***Warning: This repo is for internal Code42 use and may change or seize to exist at any time.***
+***Warning: This repo is for internal Code42 use and may change or cease to exist at any time.***
 
 To start the servers:
 
@@ -142,6 +142,39 @@ the mock key-value store endpoint).
 ```
 
 Notice the port number appears in three places in the `yml` for the docker-compose file.
+
+## Integration Tests and CI/CD
+
+To successfully execute integration tests against the mock server in a CI/CD context, you must ensure that the `docker-compose up` command does not return before your mock microservice container is fully instantiated and ready to receive requests.
+
+First, add a healthcheck endpoint to your OpenAPI yml file:
+```yml
+  /:
+    get:
+      summary: Check the health of the mock microservice container
+      responses:
+        200:
+          description: A successful response
+          content:
+            text/plain:
+              example: healthcheck-success
+```
+
+Then, in `docker-compose.yml`, add a `healthcheck` configuration section to your service definition. Be sure to modify the port to match the port exposed by your mock microservice container.
+```yml
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:4200 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+```
+
+Finally, add a service dependency to the `health_checker` service at the bottom of `docker-compose.yml` so that the `docker-compose up` command will not return until your container is fully instantiated and responding to HTTP requests:
+```yml
+    depends_on:
+      core:
+        condition: service_healthy
+```
 
 ## Returning empty JSON responses
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       dockerfile: Dockerfile
     container_name: mock_core
     restart: always
+    network_mode: "host"
     ports:
       - "4200:4200"
     command: mock docs/core.yml -p 4200 -h 0.0.0.0
@@ -19,6 +20,7 @@ services:
       dockerfile: Dockerfile
     container_name: mock_alerts
     restart: always
+    network_mode: "host"
     ports:
       - "4201:4201"
     command: mock docs/alerts.yml -p 4201 -h 0.0.0.0
@@ -30,6 +32,7 @@ services:
       dockerfile: Dockerfile
     container_name: mock_alert_rules
     restart: always
+    network_mode: "host"
     ports:
       - "4202:4202"
     command: mock docs/alert-rules.yml -p 4202 -h 0.0.0.0
@@ -41,6 +44,7 @@ services:
       dockerfile: Dockerfile
     container_name: mock_detection_lists
     restart: always
+    network_mode: "host"
     ports:
       - "4203:4203"
     command: mock docs/detection-lists.yml -p 4203 -h 0.0.0.0
@@ -52,6 +56,7 @@ services:
       dockerfile: Dockerfile
     container_name: mock_cases
     restart: always
+    network_mode: "host"
     ports:
       - "4204:4204"
     command: mock docs/cases.yml -p 4204 -h 0.0.0.0
@@ -63,6 +68,7 @@ services:
       dockerfile: Dockerfile
     container_name: mock_storage
     restart: always
+    network_mode: "host"
     ports:
       - "4205:4205"
     command: mock docs/storage.yml -p 4205 -h 0.0.0.0
@@ -74,6 +80,7 @@ services:
       dockerfile: Dockerfile
     container_name: mock_connected_server
     restart: always
+    network_mode: "host"
     ports:
       - "4206:4206"
     command: mock docs/connected-server.yml -p 4206 -h 0.0.0.0
@@ -85,6 +92,7 @@ services:
       dockerfile: Dockerfile
     container_name: mock_audit_logs
     restart: always
+    network_mode: "host"
     ports:
       - "4207:4207"
     command: mock docs/audit-logs.yml -p 4207 -h 0.0.0.0
@@ -96,6 +104,7 @@ services:
       dockerfile: Dockerfile
     container_name: mock_file_events
     restart: always
+    network_mode: "host"
     ports:
       - "4208:4208"
     command: mock docs/file-events.yml -p 4208 -h 0.0.0.0
@@ -107,6 +116,7 @@ services:
       dockerfile: Dockerfile
     container_name: mock_preservation_data_service
     restart: always
+    network_mode: "host"
     ports:
       - "4209:4209"
     command: mock docs/preservation-data-service.yml -p 4209 -h 0.0.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       test: ["CMD-SHELL", "curl -f http://localhost:4200 || exit 1"]
       interval: 10s
       timeout: 5s
-      retries: 5
+      retries: 3
 
   alerts:
     image: c42/mock-microservice-endpoints:1.0
@@ -31,7 +31,7 @@ services:
       test: ["CMD-SHELL", "curl -f http://localhost:4201 || exit 1"]
       interval: 10s
       timeout: 5s
-      retries: 5
+      retries: 3
 
   alert_rules:
     image: c42/mock-microservice-endpoints:1.0
@@ -43,6 +43,11 @@ services:
     ports:
       - "4202:4202"
     command: mock docs/alert-rules.yml -p 4202 -h 0.0.0.0
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:4201 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
 
   detection_lists:
     image: c42/mock-microservice-endpoints:1.0
@@ -54,6 +59,11 @@ services:
     ports:
       - "4203:4203"
     command: mock docs/detection-lists.yml -p 4203 -h 0.0.0.0
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:4201 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
 
   cases:
     image: c42/mock-microservice-endpoints:1.0
@@ -76,6 +86,11 @@ services:
     ports:
       - "4205:4205"
     command: mock docs/storage.yml -p 4205 -h 0.0.0.0
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:4201 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
 
   connected_server:
     image: c42/mock-microservice-endpoints:1.0
@@ -87,6 +102,11 @@ services:
     ports:
       - "4206:4206"
     command: mock docs/connected-server.yml -p 4206 -h 0.0.0.0
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:4201 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
   
   audit_logs:
     image: c42/mock-microservice-endpoints:1.0
@@ -98,8 +118,13 @@ services:
     ports:
       - "4207:4207"
     command: mock docs/audit-logs.yml -p 4207 -h 0.0.0.0
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:4201 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
 
-  file-events:
+  file_events:
     image: c42/mock-microservice-endpoints:1.0
     build:
       context: .
@@ -109,8 +134,13 @@ services:
     ports:
       - "4208:4208"
     command: mock docs/file-events.yml -p 4208 -h 0.0.0.0
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:4201 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
 
-  preservation-data-service:
+  preservation_data_service:
     image: c42/mock-microservice-endpoints:1.0
     build:
       context: .
@@ -120,12 +150,33 @@ services:
     ports:
       - "4209:4209"
     command: mock docs/preservation-data-service.yml -p 4209 -h 0.0.0.0
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:4201 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
 
-  hello:
+  health_checker:
     image: hello-world
-    container_name: hello_world
+    container_name: health_checker
     depends_on:
       core:
         condition: service_healthy
       alerts:
+        condition: service_healthy
+      alert_rules:
+        condition: service_healthy
+      detection_lists:
+        condition: service_healthy
+      cases:
+        condition: service_healthy
+      storage:
+        condition: service_healthy
+      connected_server:
+        condition: service_healthy
+      audit_logs:
+        condition: service_healthy
+      file_events:
+        condition: service_healthy
+      preservation_data_service:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       - "4202:4202"
     command: mock docs/alert-rules.yml -p 4202 -h 0.0.0.0
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:4201 || exit 1"]
+      test: ["CMD-SHELL", "curl -f http://localhost:4202 || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 3
@@ -60,7 +60,7 @@ services:
       - "4203:4203"
     command: mock docs/detection-lists.yml -p 4203 -h 0.0.0.0
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:4201 || exit 1"]
+      test: ["CMD-SHELL", "curl -f http://localhost:4203 || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 3
@@ -75,6 +75,11 @@ services:
     ports:
       - "4204:4204"
     command: mock docs/cases.yml -p 4204 -h 0.0.0.0
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:4204 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
 
   storage:
     image: c42/mock-microservice-endpoints:1.0
@@ -87,7 +92,7 @@ services:
       - "4205:4205"
     command: mock docs/storage.yml -p 4205 -h 0.0.0.0
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:4201 || exit 1"]
+      test: ["CMD-SHELL", "curl -f http://localhost:4205 || exit 1"] 
       interval: 10s
       timeout: 5s
       retries: 3
@@ -103,7 +108,7 @@ services:
       - "4206:4206"
     command: mock docs/connected-server.yml -p 4206 -h 0.0.0.0
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:4201 || exit 1"]
+      test: ["CMD-SHELL", "curl -f http://localhost:4206 || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 3
@@ -119,7 +124,7 @@ services:
       - "4207:4207"
     command: mock docs/audit-logs.yml -p 4207 -h 0.0.0.0
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:4201 || exit 1"]
+      test: ["CMD-SHELL", "curl -f http://localhost:4207 || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 3
@@ -135,7 +140,7 @@ services:
       - "4208:4208"
     command: mock docs/file-events.yml -p 4208 -h 0.0.0.0
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:4201 || exit 1"]
+      test: ["CMD-SHELL", "curl -f http://localhost:4208 || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 3
@@ -151,7 +156,7 @@ services:
       - "4209:4209"
     command: mock docs/preservation-data-service.yml -p 4209 -h 0.0.0.0
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:4201 || exit 1"]
+      test: ["CMD-SHELL", "curl -f http://localhost:4209 || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,11 @@ services:
     ports:
       - "0.0.0.0:4200:4200"
     command: mock docs/core.yml -p 4200 -h 0.0.0.0
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:4200 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   alerts:
     image: c42/mock-microservice-endpoints:1.0
@@ -22,6 +27,11 @@ services:
     ports:
       - "4201:4201"
     command: mock docs/alerts.yml -p 4201 -h 0.0.0.0
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:4201 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   alert_rules:
     image: c42/mock-microservice-endpoints:1.0
@@ -110,3 +120,12 @@ services:
     ports:
       - "4209:4209"
     command: mock docs/preservation-data-service.yml -p 4209 -h 0.0.0.0
+
+  hello:
+    image: hello-world
+    container_name: hello_world
+    depends_on:
+      core:
+        condition: service_healthy
+      alerts:
+        condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     container_name: mock_core
     restart: always
     ports:
-      - "0.0.0.0:4200:4200"
+      - "4200:4200"
     command: mock docs/core.yml -p 4200 -h 0.0.0.0
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:4200 || exit 1"]
@@ -162,8 +162,8 @@ services:
       retries: 3
 
   health_checker:
-    image: hello-world
-    container_name: health_checker
+    build: .
+    command: [":"]
     depends_on:
       core:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,8 @@ services:
       dockerfile: Dockerfile
     container_name: mock_core
     restart: always
-    network_mode: "host"
     ports:
-      - "4200:4200"
+      - "127.0.0.1:4200:4200"
     command: mock docs/core.yml -p 4200 -h 0.0.0.0
 
   alerts:
@@ -20,7 +19,6 @@ services:
       dockerfile: Dockerfile
     container_name: mock_alerts
     restart: always
-    network_mode: "host"
     ports:
       - "4201:4201"
     command: mock docs/alerts.yml -p 4201 -h 0.0.0.0
@@ -32,7 +30,6 @@ services:
       dockerfile: Dockerfile
     container_name: mock_alert_rules
     restart: always
-    network_mode: "host"
     ports:
       - "4202:4202"
     command: mock docs/alert-rules.yml -p 4202 -h 0.0.0.0
@@ -44,7 +41,6 @@ services:
       dockerfile: Dockerfile
     container_name: mock_detection_lists
     restart: always
-    network_mode: "host"
     ports:
       - "4203:4203"
     command: mock docs/detection-lists.yml -p 4203 -h 0.0.0.0
@@ -56,7 +52,6 @@ services:
       dockerfile: Dockerfile
     container_name: mock_cases
     restart: always
-    network_mode: "host"
     ports:
       - "4204:4204"
     command: mock docs/cases.yml -p 4204 -h 0.0.0.0
@@ -68,7 +63,6 @@ services:
       dockerfile: Dockerfile
     container_name: mock_storage
     restart: always
-    network_mode: "host"
     ports:
       - "4205:4205"
     command: mock docs/storage.yml -p 4205 -h 0.0.0.0
@@ -80,7 +74,6 @@ services:
       dockerfile: Dockerfile
     container_name: mock_connected_server
     restart: always
-    network_mode: "host"
     ports:
       - "4206:4206"
     command: mock docs/connected-server.yml -p 4206 -h 0.0.0.0
@@ -92,7 +85,6 @@ services:
       dockerfile: Dockerfile
     container_name: mock_audit_logs
     restart: always
-    network_mode: "host"
     ports:
       - "4207:4207"
     command: mock docs/audit-logs.yml -p 4207 -h 0.0.0.0
@@ -104,7 +96,6 @@ services:
       dockerfile: Dockerfile
     container_name: mock_file_events
     restart: always
-    network_mode: "host"
     ports:
       - "4208:4208"
     command: mock docs/file-events.yml -p 4208 -h 0.0.0.0
@@ -116,7 +107,6 @@ services:
       dockerfile: Dockerfile
     container_name: mock_preservation_data_service
     restart: always
-    network_mode: "host"
     ports:
       - "4209:4209"
     command: mock docs/preservation-data-service.yml -p 4209 -h 0.0.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     container_name: mock_core
     restart: always
     ports:
-      - "127.0.0.1:4200:4200"
+      - "0.0.0.0:4200:4200"
     command: mock docs/core.yml -p 4200 -h 0.0.0.0
 
   alerts:

--- a/docs/alert-rules.yml
+++ b/docs/alert-rules.yml
@@ -6,6 +6,15 @@ info:
 servers:
 - url: /
 paths:
+  /:
+    get:
+      summary: Check the health of the mock microservice container
+      responses:
+        200:
+          description: A successful response
+          content:
+            text/plain:
+              example: healthcheck-success
   /svc/api/v1/Rules/update-is-enabled:
     post:
       tags:

--- a/docs/alerts.yml
+++ b/docs/alerts.yml
@@ -9,16 +9,15 @@ info:
 servers:
 - url: /
 paths:
-  # Healthcheck
   /:
     get:
+      summary: Check the health of the mock microservice container
       responses:
         200:
           description: A successful response
           content:
             text/plain:
-              example: hello
-
+              example: healthcheck-success
   /svc/api/v1/update-state:
     post:
       tags:

--- a/docs/alerts.yml
+++ b/docs/alerts.yml
@@ -9,6 +9,16 @@ info:
 servers:
 - url: /
 paths:
+  # Healthcheck
+  /:
+    get:
+      responses:
+        200:
+          description: A successful response
+          content:
+            text/plain:
+              example: hello
+
   /svc/api/v1/update-state:
     post:
       tags:

--- a/docs/audit-logs.yml
+++ b/docs/audit-logs.yml
@@ -9,6 +9,15 @@ tags:
 - name: AuditLogs
   description: A collection of data for an insider threat investigation.
 paths:
+  /:
+    get:
+      summary: Check the health of the mock microservice container
+      responses:
+        200:
+          description: A successful response
+          content:
+            text/plain:
+              example: healthcheck-success
   /rpc/search/search-audit-log:
     post:
       tags:

--- a/docs/cases.yml
+++ b/docs/cases.yml
@@ -9,6 +9,15 @@ tags:
 - name: Cases
   description: A collection of data for an insider threat investigation.
 paths:
+  /:
+    get:
+      summary: Check the health of the mock microservice container
+      responses:
+        200:
+          description: A successful response
+          content:
+            text/plain:
+              example: healthcheck-success
   /api/v1/case:
     get:
       tags:

--- a/docs/connected-server.yml
+++ b/docs/connected-server.yml
@@ -10,6 +10,15 @@ tags:
   description: A collection of data for storage archive actions.
 
 paths:
+  /:
+    get:
+      summary: Check the health of the mock microservice container
+      responses:
+        200:
+          description: A successful response
+          content:
+            text/plain:
+              example: healthcheck-success
   /api/WebRestoreSession:
     post:
       tags:

--- a/docs/core.yml
+++ b/docs/core.yml
@@ -9,6 +9,15 @@ tags:
 - name: Core
   description: A collection of data for core Code42 actions.
 paths:
+  # Healthcheck
+  /:
+    get:
+      responses:
+        200:
+          description: A successful response
+          content:
+            text/plain:
+              example: hello
 
   # AUTH
 

--- a/docs/core.yml
+++ b/docs/core.yml
@@ -9,15 +9,15 @@ tags:
 - name: Core
   description: A collection of data for core Code42 actions.
 paths:
-  # Healthcheck
   /:
     get:
+      summary: Check the health of the mock microservice container
       responses:
         200:
           description: A successful response
           content:
             text/plain:
-              example: hello
+              example: healthcheck-success
 
   # AUTH
 

--- a/docs/detection-lists.yml
+++ b/docs/detection-lists.yml
@@ -7,6 +7,15 @@ servers:
 - url: /
 - name: Detection Lists
 paths:
+  /:
+    get:
+      summary: Check the health of the mock microservice container
+      responses:
+        200:
+          description: A successful response
+          content:
+            text/plain:
+              example: healthcheck-success
   /svc/api/v2/departingemployee/get:
     post:
       tags:

--- a/docs/file-events.yml
+++ b/docs/file-events.yml
@@ -9,6 +9,15 @@ tags:
 - name: File Events
   description: Security file events detected by Code42.
 paths:
+  /:
+    get:
+      summary: Check the health of the mock microservice container
+      responses:
+        200:
+          description: A successful response
+          content:
+            text/plain:
+              example: healthcheck-success
   /forensic-search/queryservice/api/v1/fileevent:
     post:
       tags:

--- a/docs/preservation-data-service.yml
+++ b/docs/preservation-data-service.yml
@@ -8,6 +8,15 @@ servers:
 tags:
 - name: Preservation Data Service
 paths:
+  /:
+    get:
+      summary: Check the health of the mock microservice container
+      responses:
+        200:
+          description: A successful response
+          content:
+            text/plain:
+              example: healthcheck-success
   /api/v1/FileVersionListing:
     get:
       tags:

--- a/docs/storage.yml
+++ b/docs/storage.yml
@@ -10,6 +10,15 @@ tags:
   description: A collection of data for storage archive actions.
 
 paths:
+  /:
+    get:
+      summary: Check the health of the mock microservice container
+      responses:
+        200:
+          description: A successful response
+          content:
+            text/plain:
+              example: healthcheck-success
   /api/AuthToken:
     post:
       tags:


### PR DESCRIPTION
Before, there was no way to determine that the mock microservice containers spun up by docker-compose were fully instantiated by the time the command exits. This made incorporating the mock servers into a CI/CD pipeline difficult.

Now, healthchecks have been added to each of the mock server service definitions in `docker-compose.yml`. This allows CI/CD runners to be certain that when the `docker-compose up` command returns, all the mock server containers are ready to receive requests from integration tests.