### PR TITLE
Improve health check by removing hello-world image 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,8 +162,9 @@ services:
       retries: 3
 
   health_checker:
-    build: .
-    command: [":"]
+    image: c42/mock-microservice-endpoints:1.0
+    entrypoint: ["echo", "All mock server containers are responding to requests!"]
+    container_name: "health_checker"
     depends_on:
       core:
         condition: service_healthy


### PR DESCRIPTION
When merging https://github.com/code42/code42-mock-servers/pull/5, I forgot to roll back the commit where I implemented Tim's suggestion here: https://github.com/code42/code42-mock-servers/pull/5#discussion_r579491010

After thinking about Alan's suggestion involving an overridden ENTRYPOINT statement, I figured out a way to implement Tim's suggestion and remove the dummy hello-world container (replacing with a container using our image that just prints a statement when all containers are healthy).